### PR TITLE
rbx and rbx-2.0 both alias to Rubinius master on travis-ci.org; add 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 rvm:
   - 1.8.7
   - 1.9.2
+  - 1.9.3
   - ruby-head
   - ree
   - jruby
   - rbx
-  - rbx-2.0
 notifications:
   recipients:
     - weppos@weppos.net


### PR DESCRIPTION
on behalf of the travis team
